### PR TITLE
fix: use hyphenated distribution name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling", "hatch_vcs"]
 build-backend = "hatchling.build"
 
 [project]
-name = "pytask_stata"
+name = "pytask-stata"
 description = "Execute do-files with Stata and pytask."
 authors = [{ name = "Tobias Raabe", email = "raabe@posteo.de" }]
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary

- Change the project distribution name from `pytask_stata` to `pytask-stata` in `pyproject.toml`.
- Keep the import package and pytask plugin entry point as `pytask_stata`.

## Why

The latest PyPI release showed `pip install pytask_stata` because the project metadata used the underscore form. Python packaging normalizes both spellings to the same project key, but the metadata name controls what PyPI displays. Using the hyphenated distribution name aligns PyPI with the README, repository name, and existing installation instructions.

## Validation

- `uv build`
- inspected generated wheel metadata: `Name: pytask-stata`
- `$env:CI='true'; uv run pytest`
